### PR TITLE
select related objects for wine list view

### DIFF
--- a/wine_wiki/views.py
+++ b/wine_wiki/views.py
@@ -43,8 +43,10 @@ class WineListView(generic.ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        wine_list = Wine.objects.all().order_by(
-            "section__order", "subsection__order", "line_num_tot"
+        wine_list = (
+            Wine.objects.all()
+            .select_related("section", "subsection", "producer", "variety")
+            .order_by("section__order", "subsection__order", "line_num_tot")
         )
 
         grouped = defaultdict(lambda: defaultdict(list))


### PR DESCRIPTION
Adds related object fields to query result so that subsequent access to these objects doesn't trigger a new query. Reduces the number of queries executed when loading the wine list view from over 2000 to 1 and should yield a significant reduction in the page load time.